### PR TITLE
Ignore lastConnectivityTime in connected_cluster lifecycle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ resource "azapi_resource" "connected_cluster" {
       body.properties.infrastructure,
       body.properties.privateLinkState,
       body.properties.provisioningState,
+      output.properties.lastConnectivityTime,
     ]
   }
 }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.
-->

Temporary fix for https://github.com/Azure/terraform-provider-azapi/issues/1061
Closes issue highlighted in https://github.com/Azure/terraform-azurerm-avm-res-hybridcontainerservice-provisionedclusterinstance/issues/100

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
